### PR TITLE
Revert Trivy pod version

### DIFF
--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -56,7 +56,7 @@ trivy-operator:
     # We also set the image here so that trivy-operator can be deployed "standalone",
     # but this image is not used if using in-cluster Trivy.
     # Change or remove the `mode:` setting to let trivy-operator pull its own Trivy images.
-    imageRef: docker.io/giantswarm/trivy:0.28.1
+    imageRef: docker.io/giantswarm/trivy:0.24.0
     mode: ClientServer
     serverURL: "http://trivy-app:4954"
     # Resources for Trivy pods created by trivy-operator


### PR DESCRIPTION
Using a v0.28.1 or v.029.x pod with the `client` subcommand (e.g. `trivy --quiet client ...`) prints a deprecation warning in the log, which causes trivy-operator to fail to parse the report. This issue was fixed with trivy-operator 0.1.0, but we downgrade here so that we can run trivy-operator to test it while updating to v0.1.0

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
