### PR TITLE
Add push to CAPA and VCD collections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,3 +68,30 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: architect
+          name: push-to-cloud-director-app-collection
+          app_name: "trivy-operator"
+          app_collection_repo: "cloud-director-app-collection"
+          requires:
+            - push-trivy-operator-to-control-plane-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+
+      - architect/push-to-app-collection:
+          context: architect
+          name: push-to-capa-app-collection
+          app_name: "trivy-operator"
+          app_collection_repo: "capa-app-collection"
+          requires:
+            - push-trivy-operator-to-control-plane-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Push tagged releases to AWS and Azure collections.
+- Push tagged releases to AWS, Azure, CAPA, and VCD collections.
 
 ### Changed
 


### PR DESCRIPTION
Adds push to CAPA and VCD collections to align with `starboard-app` 

https://github.com/giantswarm/starboard-app/blob/cabc9050c170b5068bd982975ffde74e23c51bf3/.circleci/config.yml#L98

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
