### PR TITLE
Delete existing Service before applying 0.1.9 update

### DIFF
--- a/helm/trivy-operator/templates/crd-install/crd-job.yaml
+++ b/helm/trivy-operator/templates/crd-install/crd-job.yaml
@@ -41,6 +41,9 @@ spec:
           # piping stderr to stdout means kubectl's errors are surfaced
           # in the pod's logs.
 
+          # Workaround for broken upgrade path going to 0.1.9: https://github.com/aquasecurity/trivy-operator/issues/314
+          kubectl delete service -n $namespace trivy-operator || true
+
           kubectl apply -f /data/ 2>&1
         volumeMounts:
 {{- range $path, $_ := .Files.Glob "crds/**" }}

--- a/helm/trivy-operator/templates/crd-install/crd-job.yaml
+++ b/helm/trivy-operator/templates/crd-install/crd-job.yaml
@@ -42,9 +42,14 @@ spec:
           # in the pod's logs.
 
           # Workaround for broken upgrade path going to 0.1.9: https://github.com/aquasecurity/trivy-operator/issues/314
-          kubectl delete service -n $namespace trivy-operator || true
+          kubectl delete service -n $pod_namespace trivy-operator || true
 
           kubectl apply -f /data/ 2>&1
+        env:
+          - name: pod_namespace
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         volumeMounts:
 {{- range $path, $_ := .Files.Glob "crds/**" }}
         - name: {{ $path | base | trimSuffix ".yaml" | replace "_" "-" | replace "." "-" }}

--- a/helm/trivy-operator/templates/crd-install/crd-rbac.yaml
+++ b/helm/trivy-operator/templates/crd-install/crd-rbac.yaml
@@ -21,6 +21,12 @@ rules:
   - create
   - delete
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - delete
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions


### PR DESCRIPTION
Workaround for https://github.com/aquasecurity/trivy-operator/issues/314, which breaks the upgrade path.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
