### PR TITLE
Align serverUrl service name with security-pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Changed `trivy.serverUrl` from `trivy-app` to `trivy` to align with `security-pack` App naming.
+
 ## [0.2.0] - 2022-09-26
 
 ### Changed

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -84,7 +84,7 @@ trivy-operator:
     # Change or remove the `mode:` setting to let trivy-operator pull its own Trivy images.
     imageRef: docker.io/giantswarm/trivy:0.30.4
     mode: ClientServer
-    serverURL: "http://trivy-app:4954"
+    serverURL: "http://trivy:4954"
     # Resources for Trivy pods created by trivy-operator
     resources:
       requests:


### PR DESCRIPTION
In the `security-pack` we are renaming `trivy-app` to `trivy`, which causes the `serverUrl` to fail in a default setup. This PR aligns `trivy-operator` values with the `security-pack` default setup.

https://github.com/giantswarm/security-pack/blob/main/helm/security-pack/values.yaml#L79:L81

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
