### PR TITLE
Reverts the service deletion logic

### DIFF
--- a/helm/trivy-operator/templates/crd-install/crd-job.yaml
+++ b/helm/trivy-operator/templates/crd-install/crd-job.yaml
@@ -42,11 +42,6 @@ spec:
           # in the pod's logs.
 
           kubectl apply -f /data/ 2>&1
-        env:
-          - name: pod_namespace
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
         volumeMounts:
 {{- range $path, $_ := .Files.Glob "crds/**" }}
         - name: {{ $path | base | trimSuffix ".yaml" | replace "_" "-" | replace "." "-" }}

--- a/helm/trivy-operator/templates/crd-install/crd-job.yaml
+++ b/helm/trivy-operator/templates/crd-install/crd-job.yaml
@@ -41,9 +41,6 @@ spec:
           # piping stderr to stdout means kubectl's errors are surfaced
           # in the pod's logs.
 
-          # Workaround for broken upgrade path going to 0.1.9: https://github.com/aquasecurity/trivy-operator/issues/314
-          kubectl delete service -n $pod_namespace trivy-operator || true
-
           kubectl apply -f /data/ 2>&1
         env:
           - name: pod_namespace

--- a/helm/trivy-operator/templates/crd-install/crd-rbac.yaml
+++ b/helm/trivy-operator/templates/crd-install/crd-rbac.yaml
@@ -21,12 +21,6 @@ rules:
   - create
   - delete
 - apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - delete
-- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions


### PR DESCRIPTION
This PR:

- removes the service deletion logic from crd-job
- removes the service deletion capability from crd-rbac

### Testing

Description on how trivy-operator can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for trivy-operator installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
