### PR TITLE
Create network policy for trivy-operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `NetworkPolicy` for trivy-operator to ensure it works in namespaces with `deny-all` networkpolicy.
+
 ## [0.3.2] - 2022-12-21
 
 ### Changed

--- a/helm/trivy-operator/templates/_helpers.tpl
+++ b/helm/trivy-operator/templates/_helpers.tpl
@@ -118,7 +118,5 @@ app.kubernetes.io/instance: {{ .Release.Name | quote }}
 Trivy operator scanner job selector labels
 */}}
 {{- define "scannerjob.labels.selector" -}}
-vulnerabilityReport.scanner: Trivy
+app.kubernetes.io/managed-by: trivy-operator
 {{- end -}}
-
-app.kubernetes.io/managed-by: {{ include "name" . | quote }}

--- a/helm/trivy-operator/templates/_helpers.tpl
+++ b/helm/trivy-operator/templates/_helpers.tpl
@@ -79,7 +79,7 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
 {{- end }}
 
 {{/* Generate basic labels */}}
-{{- define "trivy-operator-helpers.labels" }}
+{{- define "trivy-operator-helpers.labels" -}}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: "{{ .Chart.Version }}"
@@ -91,3 +91,25 @@ heritage: {{ $.Release.Service | quote }}
 {{ toYaml .Values.commonLabels }}
 {{- end }}
 {{- end }}
+
+{{/*
+CRD installation helpers used by Giant Swarm.
+*/}}
+{{- define "trivy-operator.networkPolicy" -}}
+{{- printf "%s-%s" ( default .Chart.Name .Values.nameOverride | trunc 63 ) "networkpolicy" | replace "+" "_" | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "labels.selector" -}}
+app.kubernetes.io/name: {{ include "name" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+{{- end -}}

--- a/helm/trivy-operator/templates/_helpers.tpl
+++ b/helm/trivy-operator/templates/_helpers.tpl
@@ -93,10 +93,10 @@ heritage: {{ $.Release.Service | quote }}
 {{- end }}
 
 {{/*
-CRD installation helpers used by Giant Swarm.
+Defines NetworkPolicy name prefix
 */}}
 {{- define "trivy-operator.networkPolicy" -}}
-{{- printf "%s-%s" ( default .Chart.Name .Values.nameOverride | trunc 63 ) "networkpolicy" | replace "+" "_" | trimSuffix "-" -}}
+{{- printf "%s" ( default .Chart.Name .Values.nameOverride | trunc 63 ) | replace "+" "_" | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -107,9 +107,18 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
-Selector labels
+Trivy operator selector labels
 */}}
 {{- define "labels.selector" -}}
 app.kubernetes.io/name: {{ include "name" . | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
 {{- end -}}
+
+{{/*
+Trivy operator scanner job selector labels
+*/}}
+{{- define "scannerjob.labels.selector" -}}
+vulnerabilityReport.scanner: Trivy
+{{- end -}}
+
+app.kubernetes.io/managed-by: {{ include "name" . | quote }}

--- a/helm/trivy-operator/templates/crd-install/crd-np.yaml
+++ b/helm/trivy-operator/templates/crd-install/crd-np.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.crds.install }}
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -35,4 +34,3 @@ spec:
   policyTypes:
   - Egress
   - Ingress
-{{- end }}

--- a/helm/trivy-operator/templates/crd-install/crd-np.yaml
+++ b/helm/trivy-operator/templates/crd-install/crd-np.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.crds.install }}
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -34,3 +35,4 @@ spec:
   policyTypes:
   - Egress
   - Ingress
+{{- end }}

--- a/helm/trivy-operator/templates/networkpolicy.yaml
+++ b/helm/trivy-operator/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "trivy-operator.networkPolicy" . }}
+  name: {{ include "trivy-operator.networkPolicy" . }}-networkpolicy
   labels: {{- include "trivy-operator-helpers.labels" . | nindent 4 }}
 spec:
   policyTypes:
@@ -11,6 +11,33 @@ spec:
   podSelector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
+  egress:
+    # Allow egress to the internet to fetch database updates.
+    - to:
+      - ipBlock:
+          cidr: 0.0.0.0/0
+          # except:
+          #   - 10.0.0.0/8
+          #   - 172.16.0.0/12
+          #   - 192.168.0.0/16
+    # Allow DNS.
+    - ports:
+        - port: 53
+          protocol: UDP
+      to:
+        - namespaceSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "trivy-operator.networkPolicy" . }}-scanner-job-networkpolicy
+  labels: {{- include "trivy-operator-helpers.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      {{- include "scannerjob.labels.selector" . | nindent 6 }}
   egress:
     # Allow egress to the internet to fetch database updates.
     - to:

--- a/helm/trivy-operator/templates/networkpolicy.yaml
+++ b/helm/trivy-operator/templates/networkpolicy.yaml
@@ -12,14 +12,10 @@ spec:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
   egress:
-    # Allow egress to the internet to fetch database updates.
-    - to:
-      - ipBlock:
-          cidr: 0.0.0.0/0
-          # except:
-          #   - 10.0.0.0/8
-          #   - 172.16.0.0/12
-          #   - 192.168.0.0/16
+    # Allow egress for health checks.
+    - ports:
+      - port: 443
+        protocol: TCP
     # Allow DNS.
     - ports:
         - port: 53

--- a/helm/trivy-operator/templates/networkpolicy.yaml
+++ b/helm/trivy-operator/templates/networkpolicy.yaml
@@ -46,10 +46,6 @@ spec:
     - to:
       - ipBlock:
           cidr: 0.0.0.0/0
-          # except:
-          #   - 10.0.0.0/8
-          #   - 172.16.0.0/12
-          #   - 192.168.0.0/16
     # Allow DNS.
     - ports:
         - port: 53

--- a/helm/trivy-operator/templates/networkpolicy.yaml
+++ b/helm/trivy-operator/templates/networkpolicy.yaml
@@ -12,7 +12,7 @@ spec:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
   egress:
-    # Allow egress to connect with master nodes & health checks.
+    # Allow egress to Kubernetes API server.
     - ports:
       - port: 443
         protocol: TCP

--- a/helm/trivy-operator/templates/networkpolicy.yaml
+++ b/helm/trivy-operator/templates/networkpolicy.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "trivy-operator.networkPolicy" . }}
+  labels: {{- include "trivy-operator-helpers.labels" . | nindent 4 }}
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      {{- include "labels.selector" . | nindent 6 }}
+  egress:
+    # Allow egress to the internet to fetch database updates.
+    - to:
+      - ipBlock:
+          cidr: 0.0.0.0/0
+          # except:
+          #   - 10.0.0.0/8
+          #   - 172.16.0.0/12
+          #   - 192.168.0.0/16
+    # Allow DNS.
+    - ports:
+        - port: 53
+          protocol: UDP
+      to:
+        - namespaceSelector: {}
+---
+{{- end }}

--- a/helm/trivy-operator/templates/networkpolicy.yaml
+++ b/helm/trivy-operator/templates/networkpolicy.yaml
@@ -16,6 +16,13 @@ spec:
     - ports:
       - port: 443
         protocol: TCP
+      to:
+      - ipBlock:
+          cidr: 172.16.0.0/12
+      - ipBlock:
+          cidr: 192.168.0.0/16
+      - ipBlock:
+          cidr: 10.0.0.0/8
     # Allow DNS.
     - ports:
         - port: 53

--- a/helm/trivy-operator/templates/networkpolicy.yaml
+++ b/helm/trivy-operator/templates/networkpolicy.yaml
@@ -12,7 +12,7 @@ spec:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
   egress:
-    # Allow egress for health checks.
+    # Allow egress to connect with master nodes & health checks.
     - ports:
       - port: 443
         protocol: TCP

--- a/helm/trivy-operator/values.schema.json
+++ b/helm/trivy-operator/values.schema.json
@@ -59,6 +59,14 @@
         "name": {
             "type": "string"
         },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "podSecurityContext": {
             "type": "object",
             "properties": {
@@ -213,6 +221,9 @@
                         "configAuditScannerEnabled": {
                             "type": "boolean"
                         },
+                        "exposedSecretScannerEnabled": {
+                            "type": "boolean"
+                        },
                         "infraAssessmentScannerEnabled": {
                             "type": "boolean"
                         },
@@ -225,7 +236,7 @@
                         "scanJobsRetryDelay": {
                             "type": "string"
                         },
-                        "vulnerabilityScannerReportTTL": {
+                        "scannerReportTTL": {
                             "type": "string"
                         },
                         "vulnerabilityScannerScanOnlyCurrentRevisions": {

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -165,3 +165,4 @@ securityContext:
 
 # managedBy is similar to .Release.Service but allows to overwrite the value
 managedBy: Helm
+

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -8,6 +8,10 @@ image:
 rbac:
   pspEnabled: true
 
+# Enable network policy to allow egress connection
+networkPolicy:
+  enabled: true
+
 trivy-operator:
 
   operator:

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -131,7 +131,7 @@ crds:
 specs:
   image:
     tag: 1.24.1
-  install: true
+  install: false
   resources:
     requests:
       cpu: 100m

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -118,7 +118,7 @@ trivy-operator:
 crds:
   image:
     tag: 1.24.1
-  install: true
+  install: false
   resources:
     requests:
       cpu: 100m

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -165,4 +165,3 @@ securityContext:
 
 # managedBy is similar to .Release.Service but allows to overwrite the value
 managedBy: Helm
-

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -118,7 +118,7 @@ trivy-operator:
 crds:
   image:
     tag: 1.24.1
-  install: false
+  install: true
   resources:
     requests:
       cpu: 100m
@@ -131,7 +131,7 @@ crds:
 specs:
   image:
     tag: 1.24.1
-  install: false
+  install: true
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- Adds network policy to make trivy operator working in namespaces with deny all policy

Closes https://github.com/giantswarm/giantswarm/issues/21420

### Testing

Description on how trivy-operator can be tested.

Install trivy & trivy-operator in a namespace with deny all network policy. The `vulnerabilityreports` must be generated with this PR.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
