### PR TITLE
Added tag field to control trivy image versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added `tag` field to control trivy image versioning.
+
 ## [0.3.6] - 2023-03-27
 
 ### Changed

--- a/helm/trivy-operator/values.schema.json
+++ b/helm/trivy-operator/values.schema.json
@@ -365,6 +365,9 @@
                         },
                         "serverURL": {
                             "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
                         }
                     }
                 },

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -98,7 +98,7 @@ trivy-operator:
     # but this image is not used if using in-cluster Trivy.
     # Change or remove the `mode:` setting to let trivy-operator pull its own Trivy images.
     repository: docker.io/giantswarm/trivy
-    tag: 0.30.4
+    tag: 0.37.2
     mode: ClientServer
     serverURL: "http://trivy:4954"
     # Resources for Trivy pods created by trivy-operator

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -98,6 +98,7 @@ trivy-operator:
     # but this image is not used if using in-cluster Trivy.
     # Change or remove the `mode:` setting to let trivy-operator pull its own Trivy images.
     repository: docker.io/giantswarm/trivy
+    tag: 0.30.4
     mode: ClientServer
     serverURL: "http://trivy:4954"
     # Resources for Trivy pods created by trivy-operator


### PR DESCRIPTION
### This PR:

Towards https://github.com/giantswarm/giantswarm/issues/26213

In reference to https://github.com/giantswarm/trivy-operator-app/pull/60#discussion_r1149469572, added tag field in `values.yaml` to control trivy image versioning.

The tag value, `0.30.4` is referenced from [v0.3.5 release](https://github.com/giantswarm/trivy-operator-app/blob/v0.3.5/helm/trivy-operator/values.yaml#L100).

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
