### PR TITLE
Enabled serviceMonitor for trivy-operator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Replace deprecated toleration `node-role.kubernetes.io/master` with `node-role.kubernetes.io/control-plane` on `CRD` and `Spec` install jobs.
+- Enabled `serviceMonitor` in the values file.
 
 ## [0.4.0] - 2023-04-28
 

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -182,5 +182,12 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
+serviceMonitor:
+  enabled: true
+  # -- (duration) Prometheus scrape interval.
+  interval: "60s"
+  # -- (duration) Prometheus scrape timeout.
+  scrapeTimeout: "45s"
+
 # managedBy is similar to .Release.Service but allows to overwrite the value
 managedBy: Helm


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/27563
In here I've enabled the serviceMonitor in the values file. 
Upstream charts already had taken serviceMonitor into account, so I assumed all I had to do was enable it. 

