### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.5.1] - 2023-12-18
 
 ### Changed

--- a/helm/trivy-operator/charts/trivy-operator/values.yaml
+++ b/helm/trivy-operator/charts/trivy-operator/values.yaml
@@ -38,7 +38,7 @@ operator:
   replicas: 1
 
   # -- number of old history to retain to allow rollback (if not set, default Kubernetes value is set to 10)
-  revisionHistoryLimit: ~
+  revisionHistoryLimit:
 
   # -- additional labels for the operator pod
   podLabels: {}
@@ -165,9 +165,9 @@ serviceMonitor:
   # -- enabled determines whether a serviceMonitor should be deployed
   enabled: false
   # -- The namespace where Prometheus expects to find service monitors
-  namespace: ~
+  namespace:
   # -- Interval at which metrics should be scraped. If not specified Prometheus’ global scrape interval is used.
-  interval: ~
+  interval:
   # -- Additional annotations for the serviceMonitor
   annotations: {}
   # -- Additional labels for the serviceMonitor
@@ -267,7 +267,7 @@ trivy:
     tag: 0.45.1
     # -- imagePullSecret is the secret name to be used when pulling trivy image from private registries example : reg-secret
     # It is the user responsibility to create the secret for the private registry in `trivy-operator` namespace
-    imagePullSecret: ~
+    imagePullSecret:
 
     # -- pullPolicy is the imge pull policy used for trivy image , valid values are (Always, Never, IfNotPresent)
     pullPolicy: IfNotPresent
@@ -293,13 +293,13 @@ trivy:
   additionalVulnerabilityReportFields: ""
 
   # -- httpProxy is the HTTP proxy used by Trivy to download the vulnerabilities database from GitHub.
-  httpProxy: ~
+  httpProxy:
 
   # -- httpsProxy is the HTTPS proxy used by Trivy to download the vulnerabilities database from GitHub.
-  httpsProxy: ~
+  httpsProxy:
 
   # -- noProxy is a comma separated list of IPs and domain names that are not subject to proxy settings.
-  noProxy: ~
+  noProxy:
 
   # -- Registries without SSL. There can be multiple registries with different keys.
   nonSslRegistries: {}
@@ -308,7 +308,7 @@ trivy:
   #  internalRegistry: registry.registry.svc:5000
 
   # -- sslCertDir can be used to override the system default locations for SSL certificate files directory, example: /ssl/certs
-  sslCertDir: ~
+  sslCertDir:
 
   # -- The registry to which insecure connections are allowed. There can be multiple registries with different keys.
   insecureRegistries: {}
@@ -342,7 +342,7 @@ trivy:
   timeout: "5m0s"
 
   # -- ignoreFile can be used to tell Trivy to ignore vulnerabilities by ID (one per line)
-  ignoreFile: ~
+  ignoreFile:
   # ignoreFile: |
   #   CVE-1970-0001
   #   CVE-1970-0002
@@ -359,7 +359,7 @@ trivy:
   #   # applies to all other workloads
 
   # -- vulnType can be used to tell Trivy to filter vulnerabilities by a pkg-type (library, os)
-  vulnType: ~
+  vulnType:
 
   # -- resources resource requests and limits for scan job containers
   resources:
@@ -374,7 +374,7 @@ trivy:
 
   # -- githubToken is the GitHub access token used by Trivy to download the vulnerabilities
   # database from GitHub. Only applicable in Standalone mode.
-  githubToken: ~
+  githubToken:
 
   # -- serverURL is the endpoint URL of the Trivy server. Required in ClientServer mode.
   #
@@ -392,7 +392,7 @@ trivy:
 
   # -- serverToken is the token to authenticate Trivy client with Trivy server. Only
   # applicable in ClientServer mode.
-  serverToken: ~
+  serverToken:
 
   # -- existingSecret if a secret containing gitHubToken, serverToken or serverCustomHeaders has been created outside the chart (e.g external-secrets, sops, etc...).
   # Keys must be at least one of the following: trivy.githubToken, trivy.serverToken, trivy.serverCustomHeaders
@@ -407,7 +407,7 @@ trivy:
 
   # -- serverCustomHeaders is a comma separated list of custom HTTP headers sent by
   # Trivy client to Trivy server. Only applicable in ClientServer mode.
-  serverCustomHeaders: ~
+  serverCustomHeaders:
   # serverCustomHeaders: "foo=bar"
 
   dbRegistry: "ghcr.io"
@@ -547,7 +547,7 @@ nodeCollector:
   tag: 0.0.8
   # -- imagePullSecret is the secret name to be used when pulling node-collector image from private registries example : reg-secret
   # It is the user responsibility to create the secret for the private registry in `trivy-operator` namespace
-  imagePullSecret: ~
+  imagePullSecret:
   # -- excludeNodes comma-separated node labels that the node-collector job should exclude from scanning (example kubernetes.io/arch=arm64,team=dev)
   excludeNodes:
   # -- node-collector pod volumeMounts definition for collecting config files information

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -6,12 +6,12 @@ serviceType: managed
 # If left blank, the chart will default to the individually set 'image.registry' values
 global:
   image:
-    registry: "docker.io"
+    registry: "gsoci.azurecr.io"
   podSecurityStandards:
     enforced: false
 
 image:
-  registry: "docker.io"
+  registry: "gsoci.azurecr.io"
 
 # Enable trivy-operator network policy.
 networkPolicy:
@@ -83,7 +83,7 @@ trivy-operator:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - ALL
+          - ALL
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
@@ -105,7 +105,7 @@ trivy-operator:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - ALL
+        - ALL
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
@@ -176,7 +176,7 @@ securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
-    - ALL
+      - ALL
   privileged: false
   readOnlyRootFilesystem: true
   runAsNonRoot: true


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
