### PR TITLE
Enable servicemonitor, change service metricsport, and disable default finding metrics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed the CIS PSP to also be used when cluster compliance scanning is enabled.
 - Configure `gsoci.azurecr.io` as the default container image registry.
+- Enabled service monitor.
+- Changed metricsport value from `80` to `8080`.
+- Changed the default findingsmetrics value from `true` to `false`.
 
 ## [0.5.1] - 2023-12-18
 

--- a/helm/trivy-operator/values.schema.json
+++ b/helm/trivy-operator/values.schema.json
@@ -254,6 +254,9 @@
                         "infraAssessmentScannerEnabled": {
                             "type": "boolean"
                         },
+                        "metricsFindingsEnabled": {
+                            "type": "boolean"
+                        },
                         "rbacAssessmentScannerEnabled": {
                             "type": "boolean"
                         },
@@ -338,11 +341,38 @@
                         }
                     }
                 },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "metricsPort": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "serviceAccount": {
                     "type": "object",
                     "properties": {
                         "name": {
                             "type": "string"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "labels": {
+                            "type": "object",
+                            "properties": {
+                                "application.giantswarm.io/team": {
+                                    "type": "string"
+                                }
+                            }
                         }
                     }
                 },

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -51,6 +51,7 @@ trivy-operator:
     clusterComplianceEnabled: false
     # exposedSecretScannerEnabled the flag to enable exposed secret scanner
     exposedSecretScannerEnabled: false
+    metricsFindingsEnabled: false
     # Reports are automatically deleted after this duration, causing a re-scan. Empty = never delete.
     scannerReportTTL: "168h"  # 7 days
     # Generate reports for only the currently-deployed version of a replicaset.
@@ -77,6 +78,15 @@ trivy-operator:
   - key: "node-role.kubernetes.io/master"
     operator: "Exists"
     effect: "NoSchedule"
+
+  service:
+    metricsPort: 8080
+
+  serviceMonitor:
+    enabled: true
+    interval: "60s"
+    labels:
+      application.giantswarm.io/team: shield
 
   trivyOperator:
 


### PR DESCRIPTION
### This PR:

- Enables the servicemonitor.
- Changes the service metrics port to `8080`
- disables the default findingmetrics to prevent double metrics (due to starboard exporter)

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
