### PR TITLE
Update CiliumNetworkPolicy to enable access to port 8080

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configure `gsoci.azurecr.io` as the default container image registry.
 - Enabled service monitor.
 - Changed metricsport value from `80` to `8080`.
+- Update CiliumNetworkPolicy to enable access to port 8080.
 
 ## [0.5.1] - 2023-12-18
 

--- a/helm/trivy-operator/templates/ciliumnetworkpolicy.yaml
+++ b/helm/trivy-operator/templates/ciliumnetworkpolicy.yaml
@@ -22,6 +22,12 @@ spec:
         - cluster
       toPorts:
         - ports:
+  ingress:
+    - fromEntities:
+      - cluster
+      toPorts:
+      - ports:
+        - port: "8080"
 ---
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/29581

### This PR:

- Update CiliumNetworkPolicy to enable access to port 8080

### Checklist

- [x] Update changelog in CHANGELOG.md.
