### PR TITLE
Add a kyverno policy exception for node-collector job.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a kyverno-policy-exception for the node-collector job.
+
 ## [0.7.1] - 2024-01-31
 
 ### Changed

--- a/helm/trivy-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/trivy-operator/templates/kyverno-policy-exception.yaml
@@ -17,10 +17,11 @@ spec:
     any:
       - resources:
           kinds:
-            - job
+            - Job
+            - Pod
           namespaces:
             - {{ .Release.Namespace }}
           names:
-            - node-collector-*
+            - "node-collector-*"
   {{- end -}}
 {{- end -}}

--- a/helm/trivy-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/trivy-operator/templates/kyverno-policy-exception.yaml
@@ -13,6 +13,7 @@ spec:
       ruleNames:
         - host-namespaces
         - autogen-host-namespaces
+        - autogen-cronjob-host-namespaces
   match:
     any:
       - resources:

--- a/helm/trivy-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/trivy-operator/templates/kyverno-policy-exception.yaml
@@ -24,5 +24,4 @@ spec:
             - {{ .Release.Namespace }}
           names:
             - "node-collector-*"
-  {{- end -}}
 {{- end -}}

--- a/helm/trivy-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/trivy-operator/templates/kyverno-policy-exception.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.kyvernoPolicyExceptions.enabled }}
-  {{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" -}}
 apiVersion: kyverno.io/v2alpha1
 kind: PolicyException
 metadata:

--- a/helm/trivy-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/trivy-operator/templates/kyverno-policy-exception.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.kyvernoPolicyExceptions.enabled }}
+  {{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" -}}
+apiVersion: kyverno.io/v2alpha1
+kind: PolicyException
+metadata:
+  name: {{ include "trivy-operator-helpers.name" . }}-exception
+  namespace: {{ .Values.kyvernoPolicyExceptions.namespace | default .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+spec:
+  exceptions:
+    - policyName: disallow-host-namespaces
+      ruleNames:
+        - host-namespaces
+        - autogen-host-namespaces
+  match:
+    any:
+      - resources:
+          kinds:
+            - job
+          namespaces:
+            - {{ .Release.Namespace }}
+          names:
+            - node-collector-*
+  {{- end -}}
+{{- end -}}

--- a/helm/trivy-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/trivy-operator/templates/kyverno-policy-exception.yaml
@@ -20,6 +20,7 @@ spec:
           kinds:
             - Job
             - Pod
+            - Cronjob
           namespaces:
             - {{ .Release.Namespace }}
           names:

--- a/helm/trivy-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/trivy-operator/templates/kyverno-policy-exception.yaml
@@ -19,7 +19,7 @@ spec:
           kinds:
             - Job
             - Pod
-            - Cronjob
+            - CronJob
           namespaces:
             - {{ .Release.Namespace }}
           names:

--- a/helm/trivy-operator/values.schema.json
+++ b/helm/trivy-operator/values.schema.json
@@ -82,6 +82,17 @@
                 }
             }
         },
+        "kyvernoPolicyExceptions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
         "managedBy": {
             "type": "string"
         },

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -215,5 +215,9 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
+kyvernoPolicyExceptions:
+  enabled: true
+  namespace: giantswarm
+
 # managedBy is similar to .Release.Service but allows to overwrite the value
 managedBy: Helm


### PR DESCRIPTION
### This PR:

- adds a kyverno policy exception allowing the node-collector job to share host-namespaces.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
