### PR TITLE
Add an option Kyverno Policy Exception when Trivy is used in filesystem or rootfs mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added a CiliumNetworkPolicy for Node Collector jobs.
+- Added a Kyverno Policy Exception to allow scan containers to run as root when in `filesystem` or `rootfs` mode.
 
 ## [0.7.2] - 2024-01-31
 

--- a/helm/trivy-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/trivy-operator/templates/kyverno-policy-exception.yaml
@@ -25,7 +25,7 @@ spec:
           names:
             - "node-collector-*"
 ---
-{{ $TO := index . ".Values.trivy-operator"}}
+{{ $TO := index .Values "trivy-operator"}}
 {{ if or (eq $TO.trivy.command "filesystem") (eq $TO.trivy.command "rootfs") }}
 apiVersion: kyverno.io/v2alpha1
 kind: PolicyException

--- a/helm/trivy-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/trivy-operator/templates/kyverno-policy-exception.yaml
@@ -25,7 +25,8 @@ spec:
           names:
             - "node-collector-*"
 ---
-{{ if or ( eq .Values.trivy-operator.trivy.command "filesystem") (eq .Values.trivy-operator.trivy.command "rootfs") }}
+{{ $TO := index . ".Values.trivy-operator"}}
+{{ if or (eq $TO.trivy.command "filesystem") (eq $TO.trivy.command "rootfs") }}
 apiVersion: kyverno.io/v2alpha1
 kind: PolicyException
 metadata:
@@ -56,4 +57,5 @@ spec:
             - {{ .Release.Namespace }}
           names:
             - "scan-vulnerabilityreport-*"
+{{- end -}}
 {{- end -}}

--- a/helm/trivy-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/trivy-operator/templates/kyverno-policy-exception.yaml
@@ -24,7 +24,6 @@ spec:
             - {{ .Release.Namespace }}
           names:
             - "node-collector-*"
-{{- end -}}
 ---
 {{- if or ( eq .Values.trivy-operator.trivy.command "filesystem") (eq .Values.trivy-operator.trivy.command "rootfs") }}
 apiVersion: kyverno.io/v2alpha1

--- a/helm/trivy-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/trivy-operator/templates/kyverno-policy-exception.yaml
@@ -25,7 +25,7 @@ spec:
           names:
             - "node-collector-*"
 {{- end -}}
-------------------------------------------------------------------------
+---
 {{- if or ( eq .Values.trivy-operator.trivy.command "filesystem") (eq .Values.trivy-operator.trivy.command "rootfs") }}
 apiVersion: kyverno.io/v2alpha1
 kind: PolicyException

--- a/helm/trivy-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/trivy-operator/templates/kyverno-policy-exception.yaml
@@ -25,7 +25,7 @@ spec:
           names:
             - "node-collector-*"
 ---
-{{- if or ( eq .Values.trivy-operator.trivy.command "filesystem") (eq .Values.trivy-operator.trivy.command "rootfs") }}
+{{ if or ( eq .Values.trivy-operator.trivy.command "filesystem") (eq .Values.trivy-operator.trivy.command "rootfs") }}
 apiVersion: kyverno.io/v2alpha1
 kind: PolicyException
 metadata:

--- a/helm/trivy-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/trivy-operator/templates/kyverno-policy-exception.yaml
@@ -36,7 +36,7 @@ metadata:
     "helm.sh/hook": "pre-install,pre-upgrade"
 spec:
   exceptions:
-    - policyName: require-runas-nonroot
+    - policyName: require-run-as-nonroot
       ruleNames:
         - run-as-non-root
         - autogen-run-as-non-root

--- a/helm/trivy-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/trivy-operator/templates/kyverno-policy-exception.yaml
@@ -25,3 +25,36 @@ spec:
           names:
             - "node-collector-*"
 {{- end -}}
+------------------------------------------------------------------------
+{{- if or ( eq .Values.trivy-operator.trivy.command "filesystem") (eq .Values.trivy-operator.trivy.command "rootfs") }}
+apiVersion: kyverno.io/v2alpha1
+kind: PolicyException
+metadata:
+  name: {{ include "trivy-operator-helpers.name" . }}-file-system-mode-exception
+  namespace: {{ .Values.kyvernoPolicyExceptions.namespace | default .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+spec:
+  exceptions:
+    - policyName: require-runas-nonroot
+      ruleNames:
+        - run-as-non-root
+        - autogen-run-as-non-root
+        - autogen-cronjob-run-as-non-root
+    - policyName: require-run-as-non-root-user
+      ruleNames:
+        - run-as-non-root-user
+        - autogen-run-as-non-root-user
+        - autogen-cronjob-run-as-non-root-user
+  match:
+    any:
+      - resources:
+          kinds:
+            - Job
+            - Pod
+            - CronJob
+          namespaces:
+            - {{ .Release.Namespace }}
+          names:
+            - "scan-vulnerabilityreport-*"
+{{- end -}}

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -103,9 +103,9 @@ trivy-operator:
     #   RunAsGroup: 10000
     #   RunAsNonRoot: true
     scanJobPodTemplatePodSecurityContext:
-      runAsUser: 0
-      runAsGroup: 0
-      runAsNonRoot: false
+      runAsUser: 10000
+      runAsGroup: 10000
+      runAsNonRoot: true
       seccompProfile:
         type: RuntimeDefault
 
@@ -116,9 +116,9 @@ trivy-operator:
         - ALL
       privileged: false
       readOnlyRootFilesystem: true
-      runAsNonRoot: false
-      runAsUser: 0
-      runAsGroup: 0
+      runAsNonRoot: true
+      runAsUser: 10000
+      runAsGroup: 10000
       seccompProfile:
         type: RuntimeDefault
 

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -149,7 +149,6 @@ trivy-operator:
     name: "trivy-operator"
 
   trivy:
-    command: filesystem
     # Ideally, we use the in-cluster Trivy deployed from https://github.com/giantswarm/trivy-app
     # We also set the image here so that trivy-operator can be deployed "standalone",
     # but this image is not used if using in-cluster Trivy.

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -103,9 +103,9 @@ trivy-operator:
     #   RunAsGroup: 10000
     #   RunAsNonRoot: true
     scanJobPodTemplatePodSecurityContext:
-      runAsUser: 10000
-      runAsGroup: 10000
-      runAsNonRoot: true
+      runAsUser: 0
+      runAsGroup: 0
+      runAsNonRoot: false
       seccompProfile:
         type: RuntimeDefault
 
@@ -116,9 +116,9 @@ trivy-operator:
         - ALL
       privileged: false
       readOnlyRootFilesystem: true
-      runAsNonRoot: true
-      runAsUser: 10000
-      runAsGroup: 10000
+      runAsNonRoot: false
+      runAsUser: 0
+      runAsGroup: 0
       seccompProfile:
         type: RuntimeDefault
 
@@ -149,6 +149,7 @@ trivy-operator:
     name: "trivy-operator"
 
   trivy:
+    command: filesystem
     # Ideally, we use the in-cluster Trivy deployed from https://github.com/giantswarm/trivy-app
     # We also set the image here so that trivy-operator can be deployed "standalone",
     # but this image is not used if using in-cluster Trivy.


### PR DESCRIPTION
### This PR:

- Add a kyverno policy exception for the trivy scan jobs when running in filesystem or rootfs mode.