### PR TITLE
Expand Kyverno Policy Exception and Change CNP to fix Trivy issues in leopard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a CiliumNetworkPolicy for Node Collector jobs.
 - Added a Kyverno Policy Exception to allow scan containers to run as root when in `filesystem` or `rootfs` mode.
 
+### Changed
+
+- Expanded the Kyverno Policy Exception for the Node Collector.
+
 ## [0.7.2] - 2024-01-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Expanded the Kyverno Policy Exception for the Node Collector.
+- Changed the Cilium Network Policy template to allow FQDN/DNS.
 
 ## [0.7.2] - 2024-01-31
 

--- a/helm/trivy-operator/templates/ciliumnetworkpolicy.yaml
+++ b/helm/trivy-operator/templates/ciliumnetworkpolicy.yaml
@@ -53,9 +53,45 @@ spec:
         - cluster
       toPorts:
         - ports:
-            - port: "53"
-            - port: "1053"
             - port: "{{ .Values.trivyServicePort | default 4954 }}"
+      {{- if .Values.ciliumNetworkPolicy.scanJobExtraEgress.enabled }}
+    # Allow DNS for FQDN resolution
+    - toEndpoints:
+      - matchLabels:
+          "k8s:io.kubernetes.pod.namespace": kube-system
+          "k8s:k8s-app": coredns
+      - matchLabels:
+          "k8s:io.kubernetes.pod.namespace": kube-system
+          "k8s:k8s-app": k8s-dns-node-cache
+      toPorts:
+      - ports:
+          - port: "1053"
+            protocol: ANY
+          - port: "53"
+            protocol: ANY
+        rules:
+          dns:
+          {{- if .Values.ciliumNetworkPolicy.scanJobExtraEgress.dnsSelector.rules -}}
+            {{- with .Values.ciliumNetworkPolicy.scanJobExtraEgress.dnsSelector.rules -}}
+            {{ toYaml . | nindent 10 }}
+            {{- end }}
+          {{- else }}
+          - matchPattern: "*"
+          {{- end }}
+    # Allow FQDNs connection
+    - toFQDNs:
+    {{- if .Values.ciliumNetworkPolicy.scanJobExtraEgress.fqdnsConnection.rules -}}
+      {{- with .Values.ciliumNetworkPolicy.scanJobExtraEgress.fqdnsConnection.rules -}}
+      {{ toYaml .| nindent 6 }}
+      {{- end }}
+    {{- else }}
+      - matchPattern: "*"
+    {{- end }}
+      toPorts:
+        - ports:
+            - port: {{ default "443" .Values.ciliumNetworkPolicy.scanJobExtraEgress.fqdnsConnection.port | quote }}
+              protocol: {{ default "TCP" .Values.ciliumNetworkPolicy.scanJobExtraEgress.fqdnsConnection.protocol }}
+  {{- end }}
 ---
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy

--- a/helm/trivy-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/trivy-operator/templates/kyverno-policy-exception.yaml
@@ -13,6 +13,16 @@ spec:
         - host-namespaces
         - autogen-host-namespaces
         - autogen-cronjob-host-namespaces
+    - policyName: disallow-host-path
+      ruleNames:
+        - host-path
+        - autogen-host-path
+        - autogen-cronjob-host-path
+    - policyName: restrict-volume-types
+      ruleNames:
+        - restricted-volumes
+        - autogen-restricted-volumes
+        - autogen-cronjob-restricted-volumes
   match:
     any:
       - resources:

--- a/helm/trivy-operator/values.schema.json
+++ b/helm/trivy-operator/values.schema.json
@@ -7,6 +7,36 @@
             "properties": {
                 "enabled": {
                     "type": "boolean"
+                },
+                "scanJobExtraEgress": {
+                    "type": "object",
+                    "properties": {
+                        "dnsSelector": {
+                            "type": "object",
+                            "properties": {
+                                "rules": {
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "fqdnsConnection": {
+                            "type": "object",
+                            "properties": {
+                                "port": {
+                                    "type": "string"
+                                },
+                                "protocol": {
+                                    "type": "string"
+                                },
+                                "rules": {
+                                    "type": "array"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -407,6 +437,9 @@
                 "trivy": {
                     "type": "object",
                     "properties": {
+                        "command": {
+                            "type": "string"
+                        },
                         "image": {
                             "type": "object",
                             "properties": {

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -20,6 +20,19 @@ networkPolicy:
 # Enable additional equivalent policy for clusters using cilium.
 ciliumNetworkPolicy:
   enabled: true
+  scanJobExtraEgress:
+    enabled: false
+    dnsSelector:
+      rules: []
+      # - matchPattern: "*"
+      # - matchPattern: "*.amazonaws.com"
+    fqdnsConnection:
+      port: "443"     # Defaults to 443 if not set
+      protocol: TCP   # Defaults to TCP if not set
+      rules: []
+      # - matchPattern: "*"
+      # - matchPattern: "s3.*.amazonaws.com"
+      # - matchName: "s3.eu-west-1.amazonaws.com"
 
 # Must match the value in trivy-operator.trivy.serverURL.
 # These should be templated in properly when possible.


### PR DESCRIPTION
### This PR:

- Gives more kyverno policy exceptions to the node-collector.
- Changes the cilium network policy to allow FQDN DNS lookups.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
