### PR TITLE
Update PolicyExceptions to v2beta1

### DIFF
--- a/helm/trivy-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/trivy-operator/templates/kyverno-policy-exception.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kyvernoPolicyExceptions.enabled }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: {{ include "trivy-operator-helpers.name" . }}-exception
@@ -27,7 +27,7 @@ spec:
 ---
 {{ $TO := index .Values "trivy-operator"}}
 {{ if or (eq $TO.trivy.command "filesystem") (eq $TO.trivy.command "rootfs") }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: {{ include "trivy-operator-helpers.name" . }}-file-system-mode-exception


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.