### PR TITLE
Allow flowcontrol/v1beta3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Detect and use `flowcontrol/v1beta3` API if `v1` is not available.
+
 ## [0.9.0] - 2024-06-06
 
 ### Changed

--- a/helm/trivy-operator/templates/flow-schema.yaml
+++ b/helm/trivy-operator/templates/flow-schema.yaml
@@ -1,6 +1,6 @@
 {{- if .Capabilities.APIVersions.Has "flowcontrol.apiserver.k8s.io/v1"}}
 apiVersion: flowcontrol.apiserver.k8s.io/v1
-{{- else if .Capabilities.APIVersions.Has "flowcontrol.apiserver.k8s.io/v1beta3" -}}
+{{- else if .Capabilities.APIVersions.Has "flowcontrol.apiserver.k8s.io/v1beta3" }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
 {{- else }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta2

--- a/helm/trivy-operator/templates/flow-schema.yaml
+++ b/helm/trivy-operator/templates/flow-schema.yaml
@@ -1,5 +1,7 @@
 {{- if .Capabilities.APIVersions.Has "flowcontrol.apiserver.k8s.io/v1"}}
 apiVersion: flowcontrol.apiserver.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "flowcontrol.apiserver.k8s.io/v1beta3" -}}
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
 {{- else }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
 {{- end }}

--- a/helm/trivy-operator/templates/priority-level-configuration.yaml
+++ b/helm/trivy-operator/templates/priority-level-configuration.yaml
@@ -1,6 +1,6 @@
-{{- if .Capabilities.APIVersions.Has "flowcontrol.apiserver.k8s.io/v1"}}
+{{- if .Capabilities.APIVersions.Has "flowcontrol.apiserver.k8s.io/v1" }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1
-{{- else if .Capabilities.APIVersions.Has "flowcontrol.apiserver.k8s.io/v1beta3" -}}
+{{- else if .Capabilities.APIVersions.Has "flowcontrol.apiserver.k8s.io/v1beta3" }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
 {{- else }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta2

--- a/helm/trivy-operator/templates/priority-level-configuration.yaml
+++ b/helm/trivy-operator/templates/priority-level-configuration.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   type: Limited
   limited:
-    assuredConcurrencyShares: 5
+    nominalConcurrencyShares: 5
     limitResponse:
       queuing:
         # Capping handSize to 10. If greater than 10, entropy bits violations kicks in.

--- a/helm/trivy-operator/templates/priority-level-configuration.yaml
+++ b/helm/trivy-operator/templates/priority-level-configuration.yaml
@@ -1,5 +1,7 @@
-{{- if .Capabilities.APIVersions.Has "flowcontrol.apiserver.k8s.io/v1" }}
+{{- if .Capabilities.APIVersions.Has "flowcontrol.apiserver.k8s.io/v1"}}
 apiVersion: flowcontrol.apiserver.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "flowcontrol.apiserver.k8s.io/v1beta3" -}}
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
 {{- else }}
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
 {{- end }}


### PR DESCRIPTION
### This PR:

- allows the chart to detect and use the flowcontrol v1beta3 API

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
