### PR TITLE
Delete SBOMs CRD when doing an upgrade and if feature is not enabled

### DIFF
--- a/helm/trivy-operator/templates/crd-install/crd-job.yaml
+++ b/helm/trivy-operator/templates/crd-install/crd-job.yaml
@@ -40,7 +40,7 @@ spec:
         - |
           set -o errexit ; set -o xtrace ; set -o nounset
           
-          {{- if .Release.IsUpgrade }}
+          {{- if and (.Release.IsUpgrade) (not .Values.trivy-operator.operator.sbomGenerationEnabled) }}
           # Delete sboms since they create conflicts
           kubectl delete crd sbomreports.aquasecurity.github.io
           kubectl delete crd clustersbomreports.aquasecurity.github.io

--- a/helm/trivy-operator/templates/crd-install/crd-job.yaml
+++ b/helm/trivy-operator/templates/crd-install/crd-job.yaml
@@ -39,7 +39,13 @@ spec:
         - -c
         - |
           set -o errexit ; set -o xtrace ; set -o nounset
-
+          
+          {{- if .Release.IsUpgrade }}
+          # Delete sboms since they create conflicts
+          kubectl delete crd sbomreports.aquasecurity.github.io
+          kubectl delete crd clustersbomreports.aquasecurity.github.io
+          {{- end }}
+          
           # piping stderr to stdout means kubectl's errors are surfaced
           # in the pod's logs.
 

--- a/helm/trivy-operator/templates/crd-install/crd-job.yaml
+++ b/helm/trivy-operator/templates/crd-install/crd-job.yaml
@@ -40,7 +40,7 @@ spec:
         - |
           set -o errexit ; set -o xtrace ; set -o nounset
           
-          {{- if and (.Release.IsUpgrade) (not .Values.trivy-operator.operator.sbomGenerationEnabled) }}
+          {{- if and (eq (index .Values "trivy-operator" "operator" "sbomGenerationEnabled") false) (.Release.IsUpgrade) }}
           # Delete sboms since they create conflicts
           kubectl delete crd sbomreports.aquasecurity.github.io
           kubectl delete crd clustersbomreports.aquasecurity.github.io


### PR DESCRIPTION
In one of the latest Trivy Operator updates, the SBOMs and ClusterSBOMs CRDs were modified and require a CRD deletion in order for the operator to work. This PR deletes the CRD before performing the upgrade.