### PR TITLE
fix: uid and gid are set from values in crd-job.yaml

### DIFF
--- a/helm/trivy-operator/templates/crd-install/crd-job.yaml
+++ b/helm/trivy-operator/templates/crd-install/crd-job.yaml
@@ -23,8 +23,6 @@ spec:
     spec:
       serviceAccountName: {{ include "trivy-operator.crdInstall" . }}
       securityContext:
-        runAsUser: 65534
-        runAsGroup: 65534
         {{- with .Values.podSecurityContext }}
         {{- . | toYaml | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
- the UID and GID are injected from values, keeping them here as well renders the chart as invalid (duplicated keys)
