### PR TITLE
Annotate scan job to exclude from http proxy cluster policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Exclude scan job pods from proxy env injection to prevent node drain failures caused by Kyverno `inject-proxy-env` policy conflicts.
+
 ## [0.12.2] - 2026-01-30
 
 ### Added

--- a/helm/trivy-operator/values.yaml
+++ b/helm/trivy-operator/values.yaml
@@ -154,6 +154,8 @@ trivy-operator:
 
   trivyOperator:
 
+    scanJobAnnotations: "policies.kyverno.io/inject-proxy-env=exclude"
+
     scanJobTolerations:
     - key: "node-role.kubernetes.io/control-plane"
       operator: "Exists"


### PR DESCRIPTION
### This PR:

I found that some nodes in tamarin couldn't drain because of the trivy scanjob pods.

The `inject-proxy-env` Kyverno `ClusterPolicy` mutates every pod on `UPDATE` by injecting HTTP_PROXY/HTTPS_PROXY/NO_PROXY env vars via `patchStrategicMerge`. This collides with the existing env vars that use `valueFrom` (configMap refs), producing a spec with both `value` and `valueFrom` on the same env entry — which the API server rejects.

Annotating those will exclude them from the policy that adds the HTTP proxy. AFAIK these don't need internet access.

Feel free to challenge this if it doesn't make sense.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
